### PR TITLE
Changed to 'pwsh'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ wsl-install
 win-install
 test-bin
 get-powershell-*.tgz
+pwsh-*.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@
 # requested version: latest, beta7
 # fake powershell is preinstalled: true, false
 
+sudo: false
 language: node_js
 node_js:
   - "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,12 @@ jobs:
       os: windows
       script:
         - npm install -g pnpm
-        - powershell -noprofile ./scripts/build.ps1 -compile -package -testWindows
+        - powershell -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -compile -package -testWindows
     - stage: test
       os: mac
       script:
-        - npm install -g pnpm
-        - powershell -noprofile ./scripts/build.ps1 -compile -package -testLinux
+        - ./.travis/test-linux.sh
     - stage: test
       os: linux
       script:
-        - npm install -g pnpm
-        - powershell -noprofile ./scripts/build.ps1 -compile -package -testLinux
+        - ./.travis/test-linux.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ jobs:
     - stage: test
       os: windows
       script:
-        - npm install -g pnpm
-        - powershell -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -compile -package -testWindows
+        - powershell -executionpolicy remotesigned -noprofile ./.travis/test-windows.ps1
     - stage: test
       os: mac
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+# Requirements:
+# A build on Linux
+# A build on Mac
+# Package into a tarball
+# Install with latest version, check "powershell -version"
+# Install with requested older version, check "powershell -version"
+# Preinstall powershell (or a fake powershell binary), install with latest version, make sure it skips installation but exposed powershell on path
+# Preinstall powershell (or a fake powershell binary), install with requested older version, make sure it skips installation but exposed powershell on path
+
+# Matrix:
+# os: linux, mac
+# requested version: latest, beta7
+# fake powershell is preinstalled: true, false
+
+language: node_js
+node_js:
+  - "10"
+# matrix:
+#     - os: windows
+#     - os: linux
+#     - os: mac
+jobs:
+  include:
+    - stage: test
+      os: windows
+      script:
+        - npm install -g pnpm
+        - powershell -noprofile ./scripts/build.ps1 -compile -package -testWindows
+    - stage: test
+      os: mac
+      script:
+        - npm install -g pnpm
+        - powershell -noprofile ./scripts/build.ps1 -compile -package -testLinux
+    - stage: test
+      os: linux
+      script:
+        - npm install -g pnpm
+        - powershell -noprofile ./scripts/build.ps1 -compile -package -testLinux

--- a/.travis/test-linux.sh
+++ b/.travis/test-linux.sh
@@ -5,5 +5,5 @@ mkdir pwsh
 pushd pwsh
 wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-linux-x64.tar.gz -o - | tar -xvz
 popd
-ln -s ./pwsh/pwsh ~/bin/pwsh
+ln -s $PWD/pwsh/pwsh ~/bin/pwsh
 pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux

--- a/.travis/test-linux.sh
+++ b/.travis/test-linux.sh
@@ -5,7 +5,5 @@ mkdir pwsh
 pushd pwsh
 wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-linux-x64.tar.gz -o - | tar -xvz
 popd
-mkdir local-bin
-ln -s ./pwsh/pwsh ./local-bin/pwsh 
-export PATH="$PWD/local-bin:$PATH"
+ln -s ./pwsh/pwsh ~/bin/pwsh
 pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux

--- a/.travis/test-linux.sh
+++ b/.travis/test-linux.sh
@@ -5,7 +5,7 @@ mkdir pwsh
 pushd pwsh
 wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-linux-x64.tar.gz -o - | tar -xvz
 popd
-mkdir bin
-ln -s ./pwsh/pwsh ./bin/pwsh 
-export PATH="$PWD/bin:$PATH"
+mkdir local-bin
+ln -s ./pwsh/pwsh ./local-bin/pwsh 
+export PATH="$PWD/local-bin:$PATH"
 pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux

--- a/.travis/test-linux.sh
+++ b/.travis/test-linux.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+npm install -g pnpm
+mkdir pwsh
+pushd pwsh
+wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-linux-x64.tar.gz -o - | tar -xvz
+popd
+mkdir bin
+ln -s ./pwsh/pwsh ./bin/pwsh 
+export PATH="$PWD/bin:$PATH"
+pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux

--- a/.travis/test-linux.sh
+++ b/.travis/test-linux.sh
@@ -6,4 +6,4 @@ pushd pwsh
 wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-linux-x64.tar.gz -o - | tar -xvz
 popd
 ln -s $PWD/pwsh/pwsh ~/bin/pwsh
-pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux
+pwsh -noprofile ./scripts/build.ps1 -installPester -compile -package -testLinux

--- a/.travis/test-mac.sh
+++ b/.travis/test-mac.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+npm install -g pnpm
+mkdir pwsh
+pushd pwsh
+wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-osx-x64.tar.gz -o - | tar -xvz
+popd
+mkdir bin
+ln -s ./pwsh/pwsh ./bin/pwsh 
+export PATH="$PWD/bin:$PATH"
+pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux

--- a/.travis/test-mac.sh
+++ b/.travis/test-mac.sh
@@ -5,7 +5,5 @@ mkdir pwsh
 pushd pwsh
 wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-osx-x64.tar.gz -o - | tar -xvz
 popd
-mkdir local-bin
-ln -s ./pwsh/pwsh ./local-bin/pwsh 
-export PATH="$PWD/local-bin:$PATH"
+ln -s ./pwsh/pwsh ~/bin/pwsh
 pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux

--- a/.travis/test-mac.sh
+++ b/.travis/test-mac.sh
@@ -6,4 +6,4 @@ pushd pwsh
 wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-osx-x64.tar.gz -o - | tar -xvz
 popd
 ln -s $PWD/pwsh/pwsh ~/bin/pwsh
-pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux
+pwsh -noprofile ./scripts/build.ps1 -installPester -compile -package -testLinux

--- a/.travis/test-mac.sh
+++ b/.travis/test-mac.sh
@@ -5,7 +5,7 @@ mkdir pwsh
 pushd pwsh
 wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-osx-x64.tar.gz -o - | tar -xvz
 popd
-mkdir bin
-ln -s ./pwsh/pwsh ./bin/pwsh 
-export PATH="$PWD/bin:$PATH"
+mkdir local-bin
+ln -s ./pwsh/pwsh ./local-bin/pwsh 
+export PATH="$PWD/local-bin:$PATH"
 pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux

--- a/.travis/test-mac.sh
+++ b/.travis/test-mac.sh
@@ -5,5 +5,5 @@ mkdir pwsh
 pushd pwsh
 wget -qO- https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/powershell-6.2.0-preview.1-osx-x64.tar.gz -o - | tar -xvz
 popd
-ln -s ./pwsh/pwsh ~/bin/pwsh
+ln -s $PWD/pwsh/pwsh ~/bin/pwsh
 pwsh -noprofile ./scripts/build.ps1 -compile -package -testLinux

--- a/.travis/test-windows.ps1
+++ b/.travis/test-windows.ps1
@@ -3,8 +3,8 @@ $ErrorActionPreference = 'Stop'
 # new-item -type directory pwsh
 # expand-archive -path pwsh.zip -outputpath pwsh
 npm install -g get-powershell@0.1.1-pwsh6.1.0
-mv $HOME\.npm-get-powershell\powershell-6.1.0-win32-x64 ./pwsh
-rm -r $HOME\.npm-get-powershell
+mv C:\ProgramData\nvs\node\10.12.0\x64\node_modules\@cspotcode\get-powershell-cache\powershell-6.1.0-win32-x64 ./pwsh
+rm -r C:\ProgramData\nvs\node\10.12.0\x64\node_modules\@cspotcode\get-powershell-cache
 npm uninstall -g get-powershell
 # $env:Path = "$(Get-Location)/pwsh;" + $env:Path
 # npm install -g pnpm

--- a/.travis/test-windows.ps1
+++ b/.travis/test-windows.ps1
@@ -1,5 +1,6 @@
 $ErrorActionPreference = 'Stop'
 $VerbosePreference = 'Continue'
+write-host 'test-windows.ps1:'
 # invoke-webrequest https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/PowerShell-6.2.0-preview.1-win-x64.zip -outfile pwsh.zip
 # new-item -type directory pwsh
 # expand-archive -path pwsh.zip -outputpath pwsh

--- a/.travis/test-windows.ps1
+++ b/.travis/test-windows.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = 'Stop'
+$VerbosePreference = 'Continue'
 # invoke-webrequest https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/PowerShell-6.2.0-preview.1-win-x64.zip -outfile pwsh.zip
 # new-item -type directory pwsh
 # expand-archive -path pwsh.zip -outputpath pwsh
@@ -7,5 +8,8 @@ mv C:\ProgramData\nvs\node\10.12.0\x64\node_modules\@cspotcode\get-powershell-ca
 rm -r C:\ProgramData\nvs\node\10.12.0\x64\node_modules\@cspotcode\get-powershell-cache
 npm uninstall -g get-powershell
 $env:Path = "$(Get-Location)/pwsh;" + $env:Path
+write-output '$env:Path ='
+write-output ($env:Path -split ';')
 npm install -g pnpm
 pwsh -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -installPester -compile -package -testWindows
+exit $LASTEXITCODE

--- a/.travis/test-windows.ps1
+++ b/.travis/test-windows.ps1
@@ -6,6 +6,6 @@ npm install -g get-powershell@0.1.1-pwsh6.1.0
 mv C:\ProgramData\nvs\node\10.12.0\x64\node_modules\@cspotcode\get-powershell-cache\powershell-6.1.0-win32-x64 ./pwsh
 rm -r C:\ProgramData\nvs\node\10.12.0\x64\node_modules\@cspotcode\get-powershell-cache
 npm uninstall -g get-powershell
-# $env:Path = "$(Get-Location)/pwsh;" + $env:Path
-# npm install -g pnpm
-# pwsh -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -compile -package -testWindows
+$env:Path = "$(Get-Location)/pwsh;" + $env:Path
+npm install -g pnpm
+pwsh -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -compile -package -testWindows

--- a/.travis/test-windows.ps1
+++ b/.travis/test-windows.ps1
@@ -8,4 +8,4 @@ rm -r C:\ProgramData\nvs\node\10.12.0\x64\node_modules\@cspotcode\get-powershell
 npm uninstall -g get-powershell
 $env:Path = "$(Get-Location)/pwsh;" + $env:Path
 npm install -g pnpm
-pwsh -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -compile -package -testWindows
+pwsh -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -installPester -compile -package -testWindows

--- a/.travis/test-windows.ps1
+++ b/.travis/test-windows.ps1
@@ -12,5 +12,5 @@ $env:Path = "$(Get-Location)/pwsh;" + $env:Path
 write-output '$env:Path ='
 write-output ($env:Path -split ';')
 npm install -g pnpm
-pwsh -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -installPester -compile -package -testWindows
+pwsh -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -installPester -compile -package -testWindows -winPwsh "$(Get-location)/pwsh/pwsh"
 exit $LASTEXITCODE

--- a/.travis/test-windows.ps1
+++ b/.travis/test-windows.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = 'Stop'
+# invoke-webrequest https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.1/PowerShell-6.2.0-preview.1-win-x64.zip -outfile pwsh.zip
+# new-item -type directory pwsh
+# expand-archive -path pwsh.zip -outputpath pwsh
+npm install -g get-powershell@0.1.1-pwsh6.1.0
+mv $HOME\.npm-get-powershell\powershell-6.1.0-win32-x64 ./pwsh
+rm -r $HOME\.npm-get-powershell
+npm uninstall -g get-powershell
+# $env:Path = "$(Get-Location)/pwsh;" + $env:Path
+# npm install -g pnpm
+# pwsh -executionpolicy remotesigned -noprofile ./scripts/build.ps1 -compile -package -testWindows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@
 
 # v0.0.8
 
-* Adds support for prerelease versions of pwsh, installable via `npm i get-powershell@prerelease`.
+* Adds support for prerelease versions of pwsh, installable via `npm i pwsh@prerelease`.
 * Adds pwsh v6.1.0-rc.1.
 
 # v0.0.7
 
 * Adds automated tests.
-* Fix issue where npm would refuse to remove the installed symlinks / cmd shims when you `npm uninstall get-powershell`
+* Fix issue where npm would refuse to remove the installed symlinks / cmd shims when you `npm uninstall pwsh`
 * Fix problem `npm install`ing a fresh git clone (only affects contributors, not consumers)
 * Switch to cross-spawn; fixes bug globally installing on Windows.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,6 @@ To compile and test:
 ./scripts/build.ps1 -compile -package -test
 ```
 
-This will run tests on Windows and Linux (via WSL).  You'll need a copy of `pwsh` installed in both Windows and Linux.  You should be able to do this via `npm install --global get-powershell`
+This will run tests on Windows and Linux (via WSL).  You'll need a copy of `pwsh` installed in both Windows and Linux.  You should be able to do this via `npm install --global pwsh`
 
 Also make sure npm and node are installed in WSL and are on your PATH.  If they're added via bashrc, you'll need to setup a `pwsh` $PROFILE to set the right PATH due to the way we invoke Linux `pwsh` to run the tests.  We read your `pwsh` $PROFILE, not your bash profile.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Alternatively, install it globally for a super-simple powershell installation.
 
 ## Why?
 
-I prefer PowerShell to bash for quickly writing npm scripts. (opinion)  However, I can't expect collaborators to have it installed.*  Adding `"get-powershell"` as a `"devDependency"` solves that problem without any extra effort.
+I prefer PowerShell to bash for quickly writing npm scripts. (opinion)  However, I can't expect collaborators to have it installed.*  Adding `"pwsh"` as a `"devDependency"` solves that problem without any extra effort.
 
 *\* Even on Windows, "Windows PowerShell" is preinstalled but we want to use `pwsh` / PowerShell Core, the cross-platform, more up-to-date edition of PowerShell.*
 
@@ -15,16 +15,16 @@ I prefer PowerShell to bash for quickly writing npm scripts. (opinion)  However,
 If you just want to use `pwsh` for your npm scripts, add us as a devDependency:
 
 ```
-npm install --save-dev get-powershell
+npm install --save-dev pwsh
 ```
 
 If you want `pwsh` to be globally available as an interactive shell:
 
 ```
-npm install --global get-powershell
+npm install --global pwsh
 ```
 
-All installations are shared, so you can depend on "get-powershell" in many projects without downloading multiple copies of `pwsh`.  See the FAQ for details.
+All installations are shared, so you can depend on "pwsh" in many projects without downloading multiple copies of `pwsh`.  See the FAQ for details.
 
 ## Example
 
@@ -32,8 +32,8 @@ All installations are shared, so you can depend on "get-powershell" in many proj
 // Example package.json
 {
     "devDependencies": {
-        // Use the latest get-powershell to install pwsh 6.0.4
-        "get-powershell": "pwsh6.0.4"
+        // Use the latest get-powershell/pwsh to install pwsh 6.0.4
+        "pwsh": "pwsh6.0.4"
     },
     "scripts": {
         "test": "pwsh -NoProfile ./scripts/test.ps1"
@@ -62,16 +62,16 @@ ls # shows all the versions installed
 ```
 
 Installations are cached and shared, so if you work on 5 different projects that all depend
-on "get-powershell", only a single copy of `pwsh` will be downloaded.  Subsequent `npm install`s should be very fast, merely creating a symlink at "./node_modules/.bin/pwsh".
+on "pwsh", only a single copy of `pwsh` will be downloaded.  Subsequent `npm install`s should be very fast, merely creating a symlink at "./node_modules/.bin/pwsh".
 
 PowerShell Core is about 50MB to download; 127MB extracted.
 
 ### How do I install a specific version of pwsh?
 
-By default we install the latest version of PowerShell Core.  To install a specific version, check the [dist-tags](https://www.npmjs.com/package/get-powershell?activeTab=versions) and install the one you want.
+By default we install the latest version of PowerShell Core.  To install a specific version, check the [dist-tags](https://www.npmjs.com/package/pwsh?activeTab=versions) and install the one you want.
 
 ```
-npm install get-powershell@pwsh6.0.4
+npm install pwsh@pwsh6.0.4
 ```
 
 *Remember, npm dist-tags !== npm versions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "get-powershell",
-  "version": "0.1.1",
+  "name": "pwsh",
+  "version": "0.2.0",
   "description": "Automatically downloads and extracts PowerShell Core, allowing you to use it in NPM scripts and node projects even with Linux and Mac developers.",
   "bin": {
     "pwsh": "./bin/pwsh"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -25,6 +25,7 @@ $ErrorActionPreference = 'Stop'
 if($test -or $testWindows) {
     $winPwsh = get-command pwsh.cmd -ea continue
     if(-not $winPwsh) { $winPwsh = get-command pwsh.exe }
+    $winPwsh = $winPwsh.source
 }
 
 function validate {
@@ -81,7 +82,7 @@ function main {
 
     if($test -or $testWindows) {
         write-host 'Testing in Windows'
-        write-host 'pwsh path: ' + $winPwsh
+        write-host ('pwsh path: ' + $winPwsh)
         & $winPwsh -noprofile -file ./test/test.ps1
         if($LASTEXITCODE -ne 0) {throw "Non-zero exit code: $LASTEXITCODE"}
     }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -81,6 +81,7 @@ function main {
 
     if($test -or $testWindows) {
         write-host 'Testing in Windows'
+        write-host 'pwsh path: ' + $winPwsh
         & $winPwsh -noprofile -file ./test/test.ps1
         if($LASTEXITCODE -ne 0) {throw "Non-zero exit code: $LASTEXITCODE"}
     }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -73,22 +73,12 @@ function main {
 
     if($test -or $testWindows) {
         write-host 'Testing in Windows'
-        & $winPwsh -noprofile -command {
-            # For some reason with -noprofile I have to Get-command to trigger loading
-            # of microsoft.powershell.utility and microsoft.powershell.management
-            # Import-Module was not working either; it was trying to load a PowerShell
-            # *Desktop* module, not *Core*.
-            # If we don't do this, pester fails to load
-            Get-Command Get-ChildItem > $null
-            Get-Command Add-Member > $null
-            import-module pester
-            invoke-pester -verbose
-        }
+        & $winPwsh -noprofile -file ./test/test.ps1
         if($LASTEXITCODE -ne 0) {throw "Non-zero exit code: $LASTEXITCODE"}
     }
     if($test -or $testLinux) {
         write-host 'Testing in Linux via WSL'
-        bash -c "bash -l -c 'pwsh -command invoke-pester'"
+        bash -c "bash -l -c 'pwsh -noprofile -file ./test/test.ps1"
     }
 
     if($prePublish) {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -21,7 +21,7 @@ $BoundParamNames = $PSBoundParameters.Keys
 $ErrorActionPreference = 'Stop'
 
 $winPwsh = get-command pwsh.cmd -ea continue
-if(-not $winPwsh) { $winPwsh = get-command pwsh.exe }
+if(-not $winPwsh) { $winPwsh = get-command pwsh.exe -ea continue }
 
 function validate {
     # if($pwshVersion -cne 'latest') {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -84,6 +84,7 @@ function main {
             import-module pester
             invoke-pester -verbose
         }
+        if($LASTEXITCODE -ne 0) {throw "Non-zero exit code: $LASTEXITCODE"}
     }
     if($test -or $testLinux) {
         write-host 'Testing in Linux via WSL'

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -87,6 +87,7 @@ function main {
     if($test -or $testLinux) {
         write-host 'Testing in Linux'
         bash -c "bash -l -c 'pwsh -noprofile -file ./test/test.ps1'"
+        if($LASTEXITCODE -ne 0) {throw "Non-zero exit code: $LASTEXITCODE"}
     }
 
     if($prePublish) {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -22,8 +22,10 @@ $BoundParamNames = $PSBoundParameters.Keys
 
 $ErrorActionPreference = 'Stop'
 
-$winPwsh = get-command pwsh.cmd -ea continue
-if(-not $winPwsh) { $winPwsh = get-command pwsh.exe }
+if($test -or $testWindows) {
+    $winPwsh = get-command pwsh.cmd -ea continue
+    if(-not $winPwsh) { $winPwsh = get-command pwsh.exe }
+}
 
 function validate {
     # if($pwshVersion -cne 'latest') {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -23,7 +23,7 @@ $BoundParamNames = $PSBoundParameters.Keys
 $ErrorActionPreference = 'Stop'
 
 $winPwsh = get-command pwsh.cmd -ea continue
-if(-not $winPwsh) { $winPwsh = get-command pwsh.exe -ea continue }
+if(-not $winPwsh) { $winPwsh = get-command pwsh.exe }
 
 function validate {
     # if($pwshVersion -cne 'latest') {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -83,8 +83,8 @@ function main {
         if($LASTEXITCODE -ne 0) {throw "Non-zero exit code: $LASTEXITCODE"}
     }
     if($test -or $testLinux) {
-        write-host 'Testing in Linux via WSL'
-        bash -c "bash -l -c 'pwsh -noprofile -file ./test/test.ps1"
+        write-host 'Testing in Linux'
+        bash -c "bash -l -c 'pwsh -noprofile -file ./test/test.ps1'"
     }
 
     if($prePublish) {

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -16,13 +16,14 @@ param(
     <# update CHANGELOG for next version #>
     [switch] $postPublish,
     [string[]] $parseVersion,
-    [switch] $dryrun
+    [switch] $dryrun,
+    [string]$winPwsh
 )
 $BoundParamNames = $PSBoundParameters.Keys
 
 $ErrorActionPreference = 'Stop'
 
-if($test -or $testWindows) {
+if(($test -or $testWindows) -and (-not $winPwsh)) {
     $winPwsh = get-command pwsh.cmd -ea continue
     if(-not $winPwsh) { $winPwsh = get-command pwsh.exe }
     $winPwsh = $winPwsh.source

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,4 +1,6 @@
 param(
+    <# install pester on CI #>
+    [switch] $installPester,
     <# compile TS and bundle via webpack #>
     [switch] $compile,
     [switch] $package,
@@ -36,6 +38,10 @@ function main {
 
     if($getPwshVersions) {
         ( getPwshVersions ).version
+    }
+
+    if($installPester) {
+        install-module -scope currentuser -force pester
     }
 
     if($compile) {

--- a/test/create-symlink.ps1
+++ b/test/create-symlink.ps1
@@ -1,0 +1,11 @@
+param(
+    $from,
+    $to
+)
+write-host $from $to
+read-host
+try {
+    new-item -type symboliclink -path $from -Target $to -EA stop
+} finally {
+    Read-host 'press enter to continue'
+}

--- a/test/main.tests.ps1
+++ b/test/main.tests.ps1
@@ -18,8 +18,10 @@ $pwshVersion = (get-content $PSScriptRoot/../dist/buildTags.json | convertfrom-j
 $npm = (Get-Command npm).Source
 $pnpm = (Get-Command pnpm).Source
 
-$winPwsh = (get-command pwsh.cmd -ea continue).path
-if(-not $winPwsh) { $winPwsh = (get-command pwsh.exe).path }
+if($IsWindows) {
+    $winPwsh = (get-command pwsh.cmd -ea continue).path
+    if(-not $winPwsh) { $winPwsh = (get-command pwsh.exe).path }
+}
 
 Describe 'get-powershell' {
     $oldLocation = Get-Location
@@ -103,7 +105,7 @@ Describe 'get-powershell' {
             remove-item -recurse $npmPrefixRealpath -force
         }
         new-item -type directory $npmPrefixRealpath
-        # symlink $npmPrefixSymlink $npmPrefixRealpath
+        symlink $npmPrefixSymlink $npmPrefixRealpath
         set-content ./.npmrc -encoding utf8 "prefix = $($npmPrefix -replace '\\','\\')"
 
         $preexistingPwsh = get-command pwsh -EA SilentlyContinue

--- a/test/main.tests.ps1
+++ b/test/main.tests.ps1
@@ -7,8 +7,8 @@ $IsPosix = $IsMacOS -or $IsLinux
 
 $pathSep = if($IsPosix) { ':' } else { ';' }
 $dirSep = if($IsPosix) { '/' } else { '\' }
-$tgz = get-item $PSScriptRoot/../get-powershell-*.tgz
-# $fromTgz = get-item $PSScriptRoot/../get-powershell-*.tgz
+$tgz = get-item $PSScriptRoot/../pwsh-*.tgz
+# $fromTgz = get-item $PSScriptRoot/../pwsh-*.tgz
 # $tgz = "./this-is-the-tgz.tgz"
 # remove-item $tgz -ea continue
 # move-item $fromTgz $tgz
@@ -122,7 +122,7 @@ Describe 'get-powershell' {
             }
             it 'pwsh is in path and is correct version' {
                 (get-command pwsh).source | should -belike "$npmLocalInstallPath*"
-                
+
                 if($pwshVersion -ne 'latest') {
                     pwsh --version | should -be "PowerShell v$pwshVersion"
                 }
@@ -140,7 +140,7 @@ Describe 'get-powershell' {
             }
             it 'pwsh is in path and is correct version' {
                 (get-command pwsh).source | should -belike "$npmLocalInstallPath*"
-                
+
                 if($pwshVersion -ne 'latest') {
                     pwsh --version | should -be "PowerShell v$pwshVersion"
                 }

--- a/test/main.tests.ps1
+++ b/test/main.tests.ps1
@@ -7,7 +7,7 @@ $IsPosix = $IsMacOS -or $IsLinux
 
 $pathSep = if($IsPosix) { ':' } else { ';' }
 $dirSep = if($IsPosix) { '/' } else { '\' }
-$tgz = get-item $PSScriptRoot/../get-powershell-*.tgz
+$tgz = "../$((get-item $PSScriptRoot/../get-powershell-*.tgz).name)"
 # $fromTgz = get-item $PSScriptRoot/../get-powershell-*.tgz
 # $tgz = "./this-is-the-tgz.tgz"
 # remove-item $tgz -ea continue
@@ -18,21 +18,36 @@ $pwshVersion = (get-content $PSScriptRoot/../dist/buildTags.json | convertfrom-j
 $npm = (Get-Command npm).Source
 $pnpm = (Get-Command pnpm).Source
 
-$winPwsh = get-command pwsh.cmd -ea continue
-if(-not $winPwsh) { $winPwsh = get-command pwsh.exe }
+$winPwsh = (get-command pwsh.cmd -ea continue).path
+if(-not $winPwsh) { $winPwsh = (get-command pwsh.exe).path }
 
 Describe 'get-powershell' {
+    $oldLocation = Get-Location
+    Set-Location $PSScriptRoot
+    $npmPrefixRealpath = "$( get-location )$( if($IsPosix) { '/real/npm-prefix-linux' } else { '\real\npm-prefix-windows' } )"
+    $npmPrefixSymlink = "$( get-location )$( if($IsPosix) { '/link-to-npm-prefix-linux' } else { '\link-to-npm-prefix-windows' } )"
+    $npmGlobalInstallPath = "$npmPrefixSymlink$( if($IsPosix) { '/bin' } else { '' } )"
+    $npmLocalInstallPath = "$PSScriptRoot$( $dirSep )node_modules$( $dirSep ).bin"
+
     BeforeEach {
         <### HELPER FUNCTIONS ###>
         function run($block) {
             & $block
             if($lastexitcode -ne 0) { throw "Non-zero exit code: $LASTEXITCODE" }
         }
-        Function npm {
-            & $npm --userconfig "$PSScriptRoot/.npmrc" @args | write-host
+        Function npm([switch]$show) {
+            if($show) {
+                & $npm --userconfig "$PSScriptRoot/.npmrc" @args 2>&1 | write-host
+            } else {
+                & $npm --userconfig "$PSScriptRoot/.npmrc" @args
+            }
         }
-        Function pnpm {
-            & $pnpm --userconfig "$PSScriptRoot/.npmrc" @args | write-host
+        Function pnpm([switch]$show) {
+            if($show) {
+                & $pnpm --userconfig "$PSScriptRoot/.npmrc" @args 2>&1 | write-host
+            } else {
+                & $pnpm --userconfig "$PSScriptRoot/.npmrc"
+            }
         }
         Function retry($times, $delay, $block) {
             while($times) {
@@ -50,29 +65,25 @@ Describe 'get-powershell' {
         }
         # Create a symlink.  On Windows this requires popping a UAC prompt (ugh)
         Function symlink($from, $to) {
+            write-host $from $to
+            write-host (get-item $from)
+            write-host (get-item $from).target
+            if((get-item $from).target -eq $to) { return }
             if($IsPosix) {
                 new-item -type symboliclink -path $from -Target $to -EA Stop
             }
             else {
                 start-process -verb runas -wait $winPwsh -argumentlist @(
-                    '-noprofile', '-c', {
-                        param($from, $to)
-                        echo new-item -type symboliclink -path $npmSymlinkPrefix -Target $npmRealpathPrefix -EA Stop
-                    }, $from, $to
-                )
+                    '-noprofile', '-file', "$PSScriptRoot/create-symlink.ps1",
+                    $from, $to
+                ) -erroraction stop
             }
         }
 
         <### SETUP ENVIRONMENT ###>
 
-        $oldLocation = Get-Location
-        Set-Location $PSScriptRoot
         # Add node_modules/.bin to PATH; remove any paths containing pwsh.exe
         $oldPath = $env:PATH
-        $npmRealpathPrefix = "$( get-location )$( if($IsPosix) { '/real/npm-prefix' } else { '\real\npm-prefix' } )"
-        $npmSymlinkPrefix = "$( get-location )$( if($IsPosix) { '/link-to-npm-prefix-linux' } else { '\link-to-npm-prefix-windows' } )"
-        $npmGlobalInstallPath = "$npmSymlinkPrefix$( if($IsPosix) { '/bin' } else { '' } )"
-        $npmLocalInstallPath = "$PSScriptRoot$( $dirSep )node_modules$( $dirSep ).bin"
         $env:PATH = (& {
             # Local bin
             $npmLocalInstallPath
@@ -88,11 +99,11 @@ Describe 'get-powershell' {
         if(test-path ./node_modules) {
             remove-item -recurse ./node_modules -force
         }
-        if(test-path ./real/npm-prefix) {
-            remove-item -recurse ./real/npm-prefix -force
+        if(test-path $npmPrefixRealpath) {
+            remove-item -recurse $npmPrefixRealpath -force
         }
-        new-item -type directory $npmRealpathPrefix
-        symlink $npmSymlinkPrefix $npmRealpathPrefix
+        new-item -type directory $npmPrefixRealpath
+        # symlink $npmPrefixSymlink $npmPrefixRealpath
         set-content ./.npmrc -encoding utf8 "prefix = $($npmPrefix -replace '\\','\\')"
 
         $preexistingPwsh = get-command pwsh -EA SilentlyContinue
@@ -100,21 +111,22 @@ Describe 'get-powershell' {
 
     }
     AfterEach {
-        Set-Location $oldLocation
-        if($IsPosix) { Remove-Item -Path $npmSymlinkPrefix }
-        else { Remove-Item -Path $npmSymlinkPrefix }
+        # if($IsPosix) { Remove-Item -Path $npmPrefixSymlink }
+        # Never delete the symlink on Windows.  It's too annoying to create in the first place
+        # else { Remove-Item -Path $npmPrefixSymlink }
         $env:PATH = $oldPath
     }
 
-    it 'Symlink exists (it requires admin privileges to create on windows and isnt done automatically)' {
-        write-host ">>$npmSymlinkPrefix"
-        Get-Item $npmSymlinkPrefix
-    }
-
     $tests = {
+
+        it 'Symlink exists (it requires admin privileges to create on windows and isnt done automatically)' {
+            Get-Item $npmPrefixSymlink
+        }
+
         it 'npm prefix set correctly for testing' {
             run { npm config get prefix } | should -be $npmPrefix
         }
+
 
         describe 'local installation via npm' {
             beforeeach {
@@ -129,14 +141,12 @@ Describe 'get-powershell' {
             }
             aftereach {
                 run { npm uninstall $tgz }
-                write-host 'deleting node_modules'
                 retry 4 1 { remove-item -r node_modules }
-                write-host 'deleted node_modules'
             }
         }
         describe 'local installation via pnpm' {
             beforeeach {
-                run { pnpm install $tgz }
+                run { pnpm -show install $tgz }
             }
             it 'pwsh is in path and is correct version' {
                 (get-command pwsh).source | should -belike "$npmLocalInstallPath*"
@@ -146,7 +156,7 @@ Describe 'get-powershell' {
                 }
             }
             aftereach {
-                run { pnpm uninstall $tgz }
+                # run { pnpm -show uninstall $tgz }
                 write-host 'deleting node_modules'
                 retry 4 1 { remove-item -r node_modules }
                 write-host 'deleted node_modules'
@@ -154,7 +164,7 @@ Describe 'get-powershell' {
         }
         describe 'global installation' {
             beforeeach {
-                run { npm install --global $tgz }
+                run { npm -show install --global $tgz }
             }
             it 'pwsh is in path and is correct version' {
                 (get-command pwsh).source | should -belike "$npmGlobalInstallPath*"
@@ -164,17 +174,20 @@ Describe 'get-powershell' {
                 }
             }
             aftereach {
-                run { npm uninstall --global $tgz }
+                run { npm -show uninstall --global $tgz }
             }
         }
     }
 
+    $npmPrefix = $npmPrefixSymlink
     describe 'npm prefix is symlink' {
-        $npmPrefix = $npmSymlinkPrefix
         . $tests
     }
+
+    $npmPrefix = $npmPrefixRealpath
     describe 'npm prefix is realpath' {
-        $npmPrefix = $npmRealpathPrefix
         . $tests
     }
+
+    Set-Location $oldLocation
 }

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Stop'
+
+# For some reason with -noprofile I have to Get-command to trigger loading
+# of microsoft.powershell.utility and microsoft.powershell.management
+# Import-Module was not working either; it was trying to load a PowerShell
+# *Desktop* module, not *Core*.
+# If we don't do this, pester fails to load
+Get-Command Get-ChildItem > $null
+Get-Command Add-Member > $null
+import-module pester
+
+invoke-pester -verbose

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -1,3 +1,4 @@
+write-host 'test.ps1: Start'
 $ErrorActionPreference = 'Stop'
 
 # For some reason with -noprofile I have to Get-command to trigger loading
@@ -9,4 +10,6 @@ Get-Command Get-ChildItem > $null
 Get-Command Add-Member > $null
 import-module pester
 
+write-host 'test.ps1: invoking pester'
 invoke-pester -verbose -enableexit
+write-host 'test.ps1: done'

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -1,5 +1,6 @@
 write-host 'test.ps1: Start'
 $ErrorActionPreference = 'Stop'
+$VerbosePreference = 'Continue'
 
 # For some reason with -noprofile I have to Get-command to trigger loading
 # of microsoft.powershell.utility and microsoft.powershell.management

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -9,4 +9,4 @@ Get-Command Get-ChildItem > $null
 Get-Command Add-Member > $null
 import-module pester
 
-invoke-pester -verbose
+invoke-pester -verbose -enableexit


### PR DESCRIPTION
This was pretty easy, but I thought I'd send it your way anyway.

I forked, renamed the `get-powershell` to `pwsh` and published a build in a private release at 

https://github.com/fearthecowboy/npm-get-powershell/releases/download/0.2.0/pwsh-0.2.0.tgz

so I can unblock myself in CI for the time being.

G