### PR TITLE
Changes to publishing workflow

### DIFF
--- a/.github/test-windows.ps1
+++ b/.github/test-windows.ps1
@@ -28,5 +28,5 @@ write-host 'BINARY PATHS:'
 (get-command pwsh).Path
 
 # Run tests
-pwsh -executionpolicy remotesigned -noprofile .\scripts\build.ps1 -compile -package -testWindows -winPwsh "$(Get-Location)\pwsh\pwsh.exe"
+pwsh -executionpolicy remotesigned -noprofile .\scripts\build.ps1 -compile -packageForTests -testWindows -winPwsh "$(Get-Location)\pwsh\pwsh.exe"
 exit $LASTEXITCODE

--- a/.github/test.sh
+++ b/.github/test.sh
@@ -37,4 +37,4 @@ which npm
 which pnpm
 which pwsh
 
-pwsh -noprofile ./scripts/build.ps1 -compile -package -testPosix
+pwsh -noprofile ./scripts/build.ps1 -compile -packageForTests -testPosix

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ test/.npmrc
 test/shrinkwrap.yaml
 test/node_modules
 test/package-lock.json
-.vscode
-pwsh
+/.vscode
+/pwsh
+/packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# UNTITLED
+# vNEXT
 
 * Move tests from Pester to mocha
 * Move from TravisCI to Github Actions
+* Tweak publishing workflow
 
 # v0.2.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwsh",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Install PowerShell Core via npm, allowing you to use it in npm scripts and node projects.",
   "bin": {
     "pwsh": "./bin/pwsh"


### PR DESCRIPTION
Splits publication step in 2, so package tarballs are all created first, then are all published to npm.
Useful for manual inspection between those steps, and to avoid issues where it fails halfway through with an error and is difficult to resume.  Now, just delete the successfully published tarballs and try again.

New set of publish steps:
* `-prepareVersion`: bump version, fixup changelog, wait for you to write changelog entry.
* `-version`: create version commit, tag in git
* `-packageForPublishing`: create all tarballs that will be published, dump in packages subdirectory for inspection, each named after its dist-tag
* `-publishPackages`: loop through the tarballs, publishing each to npm with dist-tag parsed from filename (set in previous step)
* `-postPublish`: Create empty changelog entry for next version, commit it, push commits and version tag